### PR TITLE
Use `importlib.metadata` to get project metadata for Sphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -4,21 +4,14 @@ For the full list of built-in configuration values, see the documentation:
 https://www.sphinx-doc.org/en/master/usage/configuration.html
 """
 
-from pathlib import Path
+from importlib.metadata import metadata
 
-try:
-    from tomllib import loads as toml_loads
-except ImportError:
-    from toml import loads as toml_loads
-
-from api import __version__
-
-project_config = toml_loads(Path("../../pyproject.toml").read_text())
-project: str = project_config["project"]["name"]
-release: str = __version__
-REPO_LINK: str = project_config["project"]["urls"]["repository"]
-copyright: str = project_config["tool"]["sphinx"]["copyright"]  # noqa: A001
-author: str = project_config["tool"]["sphinx"]["author"]
+project_metadata = metadata("api.letsbuilda.dev")
+project: str = project_metadata["Name"]
+release: str = project_metadata["Version"]
+REPO_LINK: str = project_metadata["Project-URL"].replace("repository, ", "")
+copyright: str = "Let's build a ..."  # noqa: A001
+author: str = "Let's build a ... community"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named "sphinx.ext.*") or your custom

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ docs = [
     "furo",
     "sphinx-autoapi",
     "releases",
-    "toml",
 ]
 
 [build-system]
@@ -44,10 +43,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]
 version = { attr = "api.__version__" }
-
-[tool.sphinx]
-copyright = "Let's build a ..."
-author = "Bradley Reynolds"
 
 [tool.black]
 target-version = ["py310"]


### PR DESCRIPTION
Use `importlib.metadata` to get project metadata for Sphinx instead of loading and parsing the `pyproject.toml`